### PR TITLE
Add role name to meta file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ To use this role add this to your playbook:
     - hosts: servers
       become: true
       roles:
-         - { role: dblenkus.postfix-aws }
+         - { role: genialis.postfix-aws }
 
 License
 -------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   role_name: postfix-aws
-  author: Domen Blenkuš
+  author: Genialis
   description: Configure Postfix to send emails through Amazon SES service.
   license: GPLv3
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
 galaxy_info:
+  role_name: postfix-aws
   author: Domen Blenkuš
   description: Configure Postfix to send emails through Amazon SES service.
   license: GPLv3


### PR DESCRIPTION
Issue: In Ansible Galaxy, the role is named "ansible_postfix_aws" instead of "postfix-aws".

Changes: updated configuration in meta/main.yml.